### PR TITLE
Style: Update typography and increase corner roundness

### DIFF
--- a/app/src/main/kotlin/de/ljz/questify/core/presentation/components/expressive/menu/ExpressiveMenuCategory.kt
+++ b/app/src/main/kotlin/de/ljz/questify/core/presentation/components/expressive/menu/ExpressiveMenuCategory.kt
@@ -31,13 +31,13 @@ fun ExpressiveMenuCategory(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(16.dp)),
+            .clip(RoundedCornerShape(28.dp)),
         verticalArrangement = Arrangement.spacedBy(2.dp)
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(4.dp))
+                .clip(RoundedCornerShape(8.dp))
                 .background(MaterialTheme.colorScheme.surfaceContainer)
         ) {
             Row(

--- a/app/src/main/kotlin/de/ljz/questify/core/presentation/components/expressive/menu/ExpressiveMenuItem.kt
+++ b/app/src/main/kotlin/de/ljz/questify/core/presentation/components/expressive/menu/ExpressiveMenuItem.kt
@@ -24,7 +24,7 @@ fun ExpressiveMenuItem(
     ListItem(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(4.dp))
+            .clip(RoundedCornerShape(8.dp))
             .clickable(enabled = onClick != null) {
                 onClick?.invoke()
             },

--- a/app/src/main/kotlin/de/ljz/questify/core/presentation/components/expressive/menu/ExpressiveMenuItemWithTextField.kt
+++ b/app/src/main/kotlin/de/ljz/questify/core/presentation/components/expressive/menu/ExpressiveMenuItemWithTextField.kt
@@ -45,7 +45,7 @@ fun ExpressiveMenuItemWithTextField(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(4.dp))
+            .clip(RoundedCornerShape(8.dp))
             .clickable(enabled = onClick != null) {
                 onClick
             }

--- a/app/src/main/kotlin/de/ljz/questify/core/presentation/components/expressive/settings/ExpressiveSettingsMenuLink.kt
+++ b/app/src/main/kotlin/de/ljz/questify/core/presentation/components/expressive/settings/ExpressiveSettingsMenuLink.kt
@@ -23,7 +23,7 @@ fun ExpressiveSettingsMenuLink(
     ListItem(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(4.dp))
+            .clip(RoundedCornerShape(8.dp))
             .clickable(enabled = onClick != null) {
                 onClick?.invoke()
             },

--- a/app/src/main/kotlin/de/ljz/questify/core/presentation/components/expressive/settings/ExpressiveSettingsSection.kt
+++ b/app/src/main/kotlin/de/ljz/questify/core/presentation/components/expressive/settings/ExpressiveSettingsSection.kt
@@ -45,7 +45,7 @@ fun ExpressiveSettingsSection(
 
         Column(
             modifier = Modifier
-                .clip(RoundedCornerShape(16.dp)),
+                .clip(RoundedCornerShape(28.dp)),
             verticalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             content()

--- a/app/src/main/kotlin/de/ljz/questify/core/presentation/components/expressive/settings/ExpressiveSettingsSwitch.kt
+++ b/app/src/main/kotlin/de/ljz/questify/core/presentation/components/expressive/settings/ExpressiveSettingsSwitch.kt
@@ -30,7 +30,7 @@ fun ExpressiveSettingsSwitch(
     ListItem(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(4.dp))
+            .clip(RoundedCornerShape(8.dp))
             .toggleable(
                 enabled = enabled,
                 value = state,

--- a/app/src/main/kotlin/de/ljz/questify/core/presentation/theme/Theme.kt
+++ b/app/src/main/kotlin/de/ljz/questify/core/presentation/theme/Theme.kt
@@ -389,6 +389,7 @@ fun QuestifyTheme(
 
     MaterialTheme(
         colorScheme = colorScheme,
+        typography = AppTypography,
         content = content
     )
 }

--- a/app/src/main/kotlin/de/ljz/questify/core/presentation/theme/Type.kt
+++ b/app/src/main/kotlin/de/ljz/questify/core/presentation/theme/Type.kt
@@ -14,14 +14,14 @@ val provider = GoogleFont.Provider(
 
 val bodyFontFamily = FontFamily(
     Font(
-        googleFont = GoogleFont("Lato"),
+        googleFont = GoogleFont("Roboto Flex"),
         fontProvider = provider,
     )
 )
 
 val displayFontFamily = FontFamily(
     Font(
-        googleFont = GoogleFont("Poppins"),
+        googleFont = GoogleFont("Roboto Flex"),
         fontProvider = provider,
     )
 )

--- a/app/src/main/kotlin/de/ljz/questify/feature/quests/presentation/screens/quests_overview/QuestOverviewScreen.kt
+++ b/app/src/main/kotlin/de/ljz/questify/feature/quests/presentation/screens/quests_overview/QuestOverviewScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -242,7 +241,7 @@ private fun QuestOverviewScreen(
                 title = {
                     Text(
                         text = "Quests",
-                        fontWeight = FontWeight.Bold
+                        style = MaterialTheme.typography.titleLarge
                     )
                 }
             )


### PR DESCRIPTION
This commit introduces visual updates across the application, primarily by changing the app's font and increasing the corner radius of various UI components for a softer look.

- **Typography:**
    - Replaced the `Lato` and `Poppins` font families with `Roboto Flex` for both body and display text, providing a more consistent and modern typographic scale.
    - Explicitly applied the `AppTypography` to the `MaterialTheme` to ensure the new font is used app-wide.
    - Updated the "Quests" title in `QuestOverviewScreen` to use `MaterialTheme.typography.titleLarge` for better semantic styling.

- **UI Corner Radius:**
    - The corner radius for `ExpressiveSettingsSection` and `ExpressiveMenuCategory` has been increased from `16.dp` to `28.dp`.
    - The corner radius for `ExpressiveMenuItem`, `ExpressiveSettingsSwitch`, `ExpressiveSettingsMenuLink`, and `ExpressiveMenuItemWithTextField` has been increased from `4.dp` to `8.dp`.